### PR TITLE
Fix types, only expose cjs and esm for hotlight-react

### DIFF
--- a/packages/hotlight-core/jest.config.js
+++ b/packages/hotlight-core/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  testEnvironment: 'jsdom'
+  testEnvironment: "jsdom",
+  moduleDirectories: ["node_modules", "src"],
 }
 

--- a/packages/hotlight-core/package.json
+++ b/packages/hotlight-core/package.json
@@ -21,7 +21,7 @@
     "build2": "rimraf ./dist && rollup -c",
     "build": "rimraf ./dist && npm run build:types && rollup -c",
     "build:types": "tsc -p ./tsconfig.json",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --env jsdom",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.js",
     "test:watch": "npm test -- --watch"
   },
   "keywords": [

--- a/packages/hotlight-react/dev/index.html
+++ b/packages/hotlight-react/dev/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Hotlight React Dev</title>
-    <script type="module" src="/hotlight-react.esm.js"></script>
+    <script type="module" src="/hotlight-react.cjs.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/hotlight-react/dev/index.ts
+++ b/packages/hotlight-react/dev/index.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import Hotlight from '../src/index';
 
 const actions = [
@@ -8,11 +9,12 @@ const actions = [
   { title: "Test", trigger: "/" },
   { title: "My action", trigger: "/" },
   { title: "Close Hotlight", trigger: ({ close }) => close() },
+  { title: "Slow trigger", trigger: async () => await new Promise((resolve) => setTimeout(() => { alert("done"); resolve("#slow") }, 5000)) },
 ]
 
 const source = () => actions;
 
-ReactDOM.render(React.createElement(Hotlight,{
+ReactDOM.render(React.createElement(Hotlight, {
   config: {
     sources: [source]
   },

--- a/packages/hotlight-react/package-lock.json
+++ b/packages/hotlight-react/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "hotlight-core": "^0.2.0"
+        "hotlight-core": "^0.2.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -8640,7 +8642,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -8653,7 +8654,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18277,7 +18277,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18287,7 +18286,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",

--- a/packages/hotlight-react/package-lock.json
+++ b/packages/hotlight-react/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "hotlight-react",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "hotlight-core": "^0.1.1"
+        "hotlight-core": "^0.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.15.8",
@@ -37,8 +37,8 @@
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2384,26 +2384,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg==",
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/@stencil/sass": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
-      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
-      "peerDependencies": {
-        "@stencil/core": ">=1.0.2"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5632,13 +5612,9 @@
       }
     },
     "node_modules/hotlight-core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hotlight-core/-/hotlight-core-0.1.1.tgz",
-      "integrity": "sha512-uo5FQr7dtAVwFxR4BwNgye9zQDhKjNxoxNxoam9Fc0CALohyE/DnrIUhb55h6iPomseVF5luSjs15/UwzgBJZQ==",
-      "dependencies": {
-        "@stencil/core": "^2.7.0",
-        "@stencil/sass": "^1.4.1"
-      }
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/hotlight-core/-/hotlight-core-0.2.0.tgz",
+      "integrity": "sha512-mcC6a9hN2OrdGU0wx3xvri7tvEutVOOZCeXHef97MCqhM1W9wkvjfBr0v4/NwpdG2DmLo+2+Jl/pdO8LxqZdOg=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -8531,23 +8507,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "peer": true
-    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -8691,28 +8650,17 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-is": {
@@ -9174,7 +9122,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13265,17 +13212,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@stencil/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-kY3xYolZoJO1MKslL0NQccHy72R3TIl1prHgfmIrEoGcnMgc6uiskdWaGMuI5/sCGz9T+QuTVz76B1H2ySyBZg=="
-    },
-    "@stencil/sass": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.5.2.tgz",
-      "integrity": "sha512-nJ93pUSylsGsMX0eLmhxh1oEljcUjj5mYjhB9ziCdoaydAdjukrUoqDCC7tdVbOcBo2hKptQyWqCtETnBGYsXQ==",
-      "requires": {}
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -15981,13 +15917,9 @@
       }
     },
     "hotlight-core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hotlight-core/-/hotlight-core-0.1.1.tgz",
-      "integrity": "sha512-uo5FQr7dtAVwFxR4BwNgye9zQDhKjNxoxNxoam9Fc0CALohyE/DnrIUhb55h6iPomseVF5luSjs15/UwzgBJZQ==",
-      "requires": {
-        "@stencil/core": "^2.7.0",
-        "@stencil/sass": "^1.4.1"
-      }
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/hotlight-core/-/hotlight-core-0.2.0.tgz",
+      "integrity": "sha512-mcC6a9hN2OrdGU0wx3xvri7tvEutVOOZCeXHef97MCqhM1W9wkvjfBr0v4/NwpdG2DmLo+2+Jl/pdO8LxqZdOg=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -18228,25 +18160,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "peer": true
-        }
-      }
-    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -18371,27 +18284,14 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "scheduler": "^0.20.2"
       }
     },
     "react-is": {
@@ -18759,7 +18659,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/packages/hotlight-react/package.json
+++ b/packages/hotlight-react/package.json
@@ -23,7 +23,9 @@
     "directory": "packages/hotlight-react"
   },
   "dependencies": {
-    "hotlight-core": "^0.2.0"
+    "hotlight-core": "^0.2.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",

--- a/packages/hotlight-react/package.json
+++ b/packages/hotlight-react/package.json
@@ -41,7 +41,6 @@
     "babel-jest": "^27.2.5",
     "babel-loader": "^8.2.2",
     "jest": "^27.2.5",
-    "react": ">=16.8.0",
     "react-test-renderer": "^17.0.2",
     "rollup": "^2.58.0",
     "rollup-plugin-copy": "^3.4.0",
@@ -52,7 +51,7 @@
     "typescript": "^4.4.3"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }

--- a/packages/hotlight-react/rollup.config.dev.js
+++ b/packages/hotlight-react/rollup.config.dev.js
@@ -1,12 +1,18 @@
 import serve from 'rollup-plugin-serve';
 import replace from '@rollup/plugin-replace';
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 import config, { plugins } from "./rollup.config";
 import typescript from '@rollup/plugin-typescript';
 
 const devConfig = {
   input: "dev/index.ts",
-  output: [config.output.filter(o => o.format === "esm")[0]],
-  plugins: plugins
+  output: [config.output.filter(o => o.format === "cjs")[0]],
+  plugins: [
+    commonjs(),
+    typescript(),
+    resolve()
+  ]
     .concat(serve({
       contentBase: ['dev', 'dist'],
       open: true

--- a/packages/hotlight-react/rollup.config.js
+++ b/packages/hotlight-react/rollup.config.js
@@ -1,42 +1,46 @@
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
-//import serve from 'rollup-plugin-serve';
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import typescript from '@rollup/plugin-typescript';
 
 export const plugins = [
+  peerDepsExternal(),
   typescript(),
-    //useTsconfigDeclarationDir: true
-  //}),
   resolve(),
   commonjs(),
 ]
 
 export default {
   input: "src/index.ts",
+  plugins: plugins.concat(),
   output: [
     {
       file: "dist/hotlight-react.cjs.js",
+      //dir: "dist/cjs",
       format: "cjs",
       sourcemap: true,
     },
     {
       file: "dist/hotlight-react.esm.js",
+      //dir: "dist/esm",
       format: "esm",
       sourcemap: true,
     },
+    /*
     {
-      file: "dist/hotlight-react.umd.js",
+      //file: "dist/hotlight-react.umd.js",
+      dir: "dist/umd",
       format: "umd",
       sourcemap: true,
       name: "HotlightReact"
     },
     {
-      file: "dist/hotlight-react.unpkg.js",
+      //file: "dist/hotlight-react.unpkg.js",
+      dir: "dist/unpkg",
       format: "iife",
       sourcemap: true,
       name: "HotlightReact"
     }
-  ],
-  plugins: plugins.concat(peerDepsExternal())
+    */
+  ]
 };

--- a/packages/hotlight-react/rollup.config.old.js
+++ b/packages/hotlight-react/rollup.config.old.js
@@ -1,0 +1,34 @@
+import peerDepsExternal from "rollup-plugin-peer-deps-external";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
+import typescript from '@rollup/plugin-typescript';
+
+export const plugins = [
+  peerDepsExternal(),
+  resolve({
+    extensions: ["ts", "tsx"]
+  }),
+  commonjs(),
+]
+
+const output = (format, typeDeclarations = false) => ({
+  input: "src/index.ts",
+  plugins: typeDeclarations ? [typescript()].concat(plugins) : plugins,
+  output: {
+    dir: format === "iife" ? "dist/unpkg" : `dist/${format}`,
+    format,
+    sourcemap: true,
+    name: ["iife", "umd"].includes(format) ? "HotlightReact" : undefined,
+  }
+})
+
+const config = [
+  output("esm", true),
+  output("cjs"),
+  output("umd"),
+  output("iife")
+];
+
+console.log(config)
+
+export default config;

--- a/packages/hotlight-react/src/Hotlight.tsx
+++ b/packages/hotlight-react/src/Hotlight.tsx
@@ -15,14 +15,14 @@ declare global {
 // this should be in the types in the dist of the component.. import them from there or add a package.json that refers to them
 
 type Props = {
-  config: any;
+  config: Config;
 }
 const Hotlight = ({ config }: Props) => {
   // Only runs client side
   useEffect(() => {
     const hl = hotlight();
     hl.configure(config);
-  })
+  }, [])
 
   return (
     <hotlight-modal />

--- a/packages/hotlight-react/tsconfig.json
+++ b/packages/hotlight-react/tsconfig.json
@@ -1,12 +1,12 @@
 {
-  "include": ["src", "types"],
-  "exclude": ["node_modules", "build"],
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
     "declaration": true,
-    "declarationDir": "dist",
+    "declarationDir": "dist/esm",
     "sourceMap": true,
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
This PR externalizes react and exposes cjs and esm packages for the `hotlight-react` package.